### PR TITLE
Added support for detecting os_type (Linux and OSX only for now)

### DIFF
--- a/bin/install-buddy
+++ b/bin/install-buddy
@@ -30,7 +30,7 @@ packagelist_yaml["packages"].each do |pkg|
   pkg_name = InstallBuddy.resolve_package(pkg, si.distro_family, si.distro)
 
   # Check if we should skip install for this distro type
-  if(InstallBuddy.skip_install?(pkg, si.distro_family, si.distro))
+  if(InstallBuddy.skip_install?(pkg, si.distro_family, si.distro, si.os_type))
     puts colorize("Skipping #{pkg_name} on #{si.distro} ...", :yellow)
     next
   end

--- a/lib/install_buddy.rb
+++ b/lib/install_buddy.rb
@@ -55,7 +55,7 @@ class InstallBuddy
   end
 
   # Should we skip installation?
-  def self.skip_install?(pkg, distro_family, distro = nil)
+  def self.skip_install?(pkg, distro_family, distro = nil, os_type = nil)
     return false unless(valid_pkg?(pkg))
 
     # Skip intallation if :only key present and distro doesn't match
@@ -68,7 +68,7 @@ class InstallBuddy
     return false if(skips.nil? || !skips.is_a?(Array))
 
     skips = skips.map(&:upcase)
-    skips.include?(distro_family.to_s) || skips.include?(distro.to_s)
+    skips.include?(distro_family.to_s) || skips.include?(distro.to_s) || skips.include?(os_type.to_s)
   end
 
   private

--- a/tests/unit/install_buddy_test.rb
+++ b/tests/unit/install_buddy_test.rb
@@ -76,6 +76,18 @@ class InstallBuddyTest < Minitest::Test
     assert_equal InstallBuddy.skip_install?(pkg, :CENTOS), true
   end
 
+  # Should skip Linux distro when in skip list even if distro's name or family does not match the word Linux
+  def test_skip_linux_with_linux_distro
+    yml = <<~YML
+      packages:
+        - macvim:
+          - skip: [ "Linux" ]
+    YML
+    pkg_hash = YAML.load(yml)
+    pkg = pkg_hash["packages"].first
+    assert_equal InstallBuddy.skip_install?(pkg, :UBUNTU, :ELEMENTARY, :LINUX), true
+  end
+
   # Should skip installation when only key present and does not match
   def test_only_install_feature
     pkg_hash = packagelist_hash


### PR DESCRIPTION
Found a bug where if trying to skip Linux (with say OSX only apps) it would not skip as the we only kept distro and distro family level info. Now we support os type as well.