### PR TITLE
Added -no-root option to install even when not root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ sudo ./bin/install-buddy -f ./conf/package-list-example.yml --dry-run
 sudo ./bin/install-buddy -f ./conf/package-list-example.yml
 ```
 
+Add `--no-root` to try force installation as non root and stop it from complaining.
+
+```bash
+sudo ./bin/install-buddy -f ./conf/package-list-example.yml --no-root
+```
+
 ## Package Alias Support
 Some packages might be named differently depending on distro.
 Eg: [the-silver-searcher](https://github.com/ggreer/the_silver_searcher), a faster alternative to `ack-grep` is named differently depending on distro. Look at the following example above on how to write it.

--- a/bin/install-buddy
+++ b/bin/install-buddy
@@ -15,7 +15,7 @@ packagelist_file = InstallBuddy.get_option(:packagelist)
 abort(Utils::colorize("#{InstallBuddy.get_usage}. Type `install-buddy -h` for more details", :yellow)) if packagelist_file.nil?
 
 # Check if running as root
-abort(Utils::colorize('install-buddy must be run as root!', :red)) unless InstallBuddy.get_option(:remote) || `id -u`.chomp == '0'
+abort(Utils::colorize('install-buddy must be run as root!', :red)) unless InstallBuddy.get_option(:remote) || `id -u`.chomp == '0' || InstallBuddy.get_option(:noroot)
 
 abort(Utils::colorize("File not found or is unreadable!", :red)) if !File.readable?(packagelist_file)
 

--- a/lib/install_buddy.rb
+++ b/lib/install_buddy.rb
@@ -8,7 +8,8 @@ class InstallBuddy
       packagelist: nil,
       remote: nil,
       debug: false,
-      dryrun: false
+      dryrun: false,
+      noroot: false
     }
 
     OptionParser.new do |opts|
@@ -28,7 +29,12 @@ class InstallBuddy
       opts.on("--dry-run", "Pretends to install packages") do
         @@OPTIONS[:dryrun] = true
       end
+      opts.on("--no-root", "Don't check if running as root (needed for homebrew)") do
+        @@OPTIONS[:noroot] = true
+      end
     end.parse!
+    rescue => e
+      abort("Bad option entered! Check your arguments.")
   end
 
   def self.get_option(key)


### PR DESCRIPTION
Newer versions of `home-brew` doesn't like running as sudo so this option can be used to force no-root as the installer will complain otherwise.