### PR TITLE
fixes for colors, shell safety

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,9 @@ source 'https://rubygems.org'
 gem 'net-ssh'
 gem 'ed25519'
 gem 'bcrypt_pbkdf'
+gem 'tty-color'
 
 group :development do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'minitest'
 end
-

--- a/bin/install-buddy
+++ b/bin/install-buddy
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require 'optparse'
 require 'yaml'
+require 'tty-color'
 require_relative '../lib/install_buddy'
 require_relative '../lib/sysinfo'
 require_relative '../lib/distro_support'
@@ -15,7 +16,7 @@ packagelist_file = InstallBuddy.get_option(:packagelist)
 abort(Utils::colorize("#{InstallBuddy.get_usage}. Type `install-buddy -h` for more details", :yellow)) if packagelist_file.nil?
 
 # Check if running as root
-abort(Utils::colorize('install-buddy must be run as root!', :red)) unless InstallBuddy.get_option(:remote) || `id -u`.chomp == '0'
+abort(Utils::colorize('install-buddy must be run as root!', :red)) unless InstallBuddy.get_option(:remote) || Process.uid == '0'
 
 abort(Utils::colorize("File not found or is unreadable!", :red)) if !File.readable?(packagelist_file)
 

--- a/lib/sysinfo.rb
+++ b/lib/sysinfo.rb
@@ -8,7 +8,7 @@ class Sysinfo
   end
 
   def self.term_supports_color?
-    @colors ||= `env tput colors 2>/dev/null`.chomp
+    @colors ||= TTY::Color.mode
     @colors.to_i > 8
   end
 


### PR DESCRIPTION
Fixes:
- use TTY::Color for seeing if the terminal supports color
- TTY::Color will also give us how many colors are supported, so it works the same way
- Remove backticks to prefer ruby native methods. This is much safer since we don't need to know about our shell now.
- Check process ID with ruby native method

Enjoy!